### PR TITLE
Use Node.js versions 18.x and 20.x for workflows

### DIFF
--- a/.github/workflows/verify-data-models.yml
+++ b/.github/workflows/verify-data-models.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [18.x, 20.x]
 
     steps:
     - name: Checkout sources


### PR DESCRIPTION
This PR updates the versions of Node.js used during CI runs.